### PR TITLE
chore: standardize PR-based release workflow

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -1,12 +1,11 @@
 name: Build, Test, and Publish
 
 on:
-  push:
-    branches: [ main ]
-    tags:
-      - 'v*'
   pull_request:
     branches: [ main ]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 permissions:
@@ -14,7 +13,8 @@ permissions:
   id-token: write
 
 jobs:
-  release:
+  validate:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -25,10 +25,34 @@ jobs:
         with:
           node-version: '20'
 
-      # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest
-        
+
+      - name: Install deps (skip lifecycle scripts to avoid duplicate build)
+        run: npm ci --ignore-scripts
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install deps (skip lifecycle scripts to avoid duplicate build)
         run: npm ci --ignore-scripts
 
@@ -39,5 +63,6 @@ jobs:
         run: npm test
 
       - name: Publish
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: all build test bump bump-minor bump-major
+
+all: build
+
+build:
+	npm run build
+
+test:
+	npm test
+
+# 🚀 Use 'make bump' to release.
+bump:
+	$(call bump_version,patch)
+
+bump-minor:
+	$(call bump_version,minor)
+
+bump-major:
+	$(call bump_version,major)
+
+define bump_version
+	@echo "Creating release branch and bumping version..."
+	@BRANCH_NAME=release-bump-$$(date +%Y%m%d-%H%M%S); \
+	git checkout -b $$BRANCH_NAME; \
+	npm version $(1); \
+	git push origin HEAD --follow-tags; \
+	NEW_VERSION=$$(node -p "require('./package.json').version"); \
+	gh pr create --fill --base main --title "chore: release v$$NEW_VERSION"
+endef


### PR DESCRIPTION
- Split workflow into validate (PR) and release (tag) jobs
- Add Makefile with bump target for PR-based releases
- Align with mqtt-graphql workflow pattern

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
